### PR TITLE
Add offline TTS and multilingual support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository provides a simple flow-based prototype that listens for a wake w
 - PortAudio installed (`brew install portaudio` on macOS)
 - [Porcupine](https://github.com/Picovoice/porcupine) and [Orca](https://github.com/picovoice/orca) API keys
 - `pyaudio` and other Python dependencies from `requirements.txt`
+- Optional: `pyttsx3` for offline text to speech
 
 ## Environment Variables
 
@@ -40,6 +41,14 @@ set the environment variable `USE_OLLAMA=1`. The step will communicate with the
 endpoint defined by `OLLAMA_ENDPOINT`.
 
 The assistant is configured to respond in a very simple "explain like I'm five" manner. It also filters replies for potentially inappropriate language so that responses remain child friendly.
+
+### Offline text to speech
+
+If no `ORCA_API_KEY` is provided the application falls back to [`pyttsx3`](https://pyttsx3.readthedocs.io/) for speech synthesis. This runs entirely locally but you need a TTS engine available on your system.
+
+### Multilingual input
+
+Speech can be provided in German, English or Spanish. The detected language is used for the reply so the assistant answers in the same language.
 
 ## Development Container
 

--- a/flow/steps/TextToSpeech.py
+++ b/flow/steps/TextToSpeech.py
@@ -3,13 +3,23 @@ import pvorca
 import tempfile
 import os
 
+try:
+    import pyttsx3
+except Exception:
+    pyttsx3 = None
+
 class TextToSpeech(FlowStep):
     # Expects a string (chat response) and returns audio data as bytes.
     expected_input_types = (str,)
     output_type = bytes
 
     def __init__(self) -> None:
-        self.orca = pvorca.create(access_key=os.getenv("ORCA_API_KEY") or "")
+        access_key = os.getenv("ORCA_API_KEY") or ""
+        self.orca = pvorca.create(access_key=access_key) if access_key else None
+        if not self.orca and pyttsx3:
+            self.engine = pyttsx3.init()
+        else:
+            self.engine = None
         super().__init__()
 
     def execute(self, input_data):
@@ -17,8 +27,15 @@ class TextToSpeech(FlowStep):
         with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_wav_file:
             temp_wav_path = temp_wav_file.name
 
-        # Synthesize speech to the temporary file
-        self.orca.synthesize_to_file(text=input_data, output_path=temp_wav_path)
+        if self.orca is not None:
+            # Synthesize speech via Orca
+            self.orca.synthesize_to_file(text=input_data, output_path=temp_wav_path)
+        elif self.engine is not None:
+            # Fallback to local pyttsx3 if available
+            self.engine.save_to_file(input_data, temp_wav_path)
+            self.engine.runAndWait()
+        else:
+            raise RuntimeError("No TTS engine available")
 
         # Load the content of the temporary file into a bytes string
         with open(temp_wav_path, 'rb') as file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ mistralai
 pvorca
 pvporcupine
 python-dotenv
+pyttsx3
+langdetect

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub mistralai so the module can be imported without the real dependency.
+mistralai_stub = types.ModuleType("mistralai")
+
+class _Mistral:
+    def __init__(self, *args, **kwargs):
+        pass
+
+mistralai_stub.Mistral = _Mistral
+sys.modules.setdefault("mistralai", mistralai_stub)
+
+from flow.steps.AskLeChat import AskLeChat
+
+
+def test_detect_language():
+    step = AskLeChat()
+    assert step._detect_language("Hello, how are you?") == "en"
+    assert step._detect_language("Wie geht es dir?") == "de"
+    assert step._detect_language("Hola, como estas?") == "es"


### PR DESCRIPTION
## Summary
- add optional `pyttsx3` fallback in `TextToSpeech`
- detect German, English or Spanish in `AskLeChat` and answer in the same language
- document offline TTS usage and multilingual input
- include new optional dependencies
- test language detection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c9b73e9a4832d956aebbdd25c4b6f